### PR TITLE
Allow installation to local repository via `gradle install`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 apply plugin : 'java-robolectric'
 apply plugin : 'idea'
+apply plugin : 'maven'
 apply from : 'ci/deploy.gradle'
+
+group 'org.ligi'
 
 buildscript {
   repositories {


### PR DESCRIPTION
- Re-enable Maven plug-in disabled in commit a5148f0e8edf33864dd7b249a7e1e812d4ca24e5
- Add missing group id to avoid error message:
  
  ``` java
  For artifact {:TraceDroid:1.4:jar}: The groupId cannot be empty.
  ```
- Resolves issue #1.
